### PR TITLE
route /data to minio container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.minio-minimo.rule=Host(`${HOST_NAME:-minimo.localhost}`)"
-      - "traefik.http.routers.minio-minimo.rule=PathPrefix(`/minio/`,`/data/`)"
+      - "traefik.http.routers.minio-minimo.rule=PathPrefix(`/minio/`,`/data{regex:$$|/.*}`)"
       - "traefik.http.routers.minio-minimo.entrypoints=web-secure"
       - "traefik.http.routers.minio-minimo.tls=true"
       - "traefik.frontend.passHostHeader=true"


### PR DESCRIPTION
### purpose ###
route /data path to minio container. this enables bucket level operations on the data bucket from a minio client

### testing ###
1: `curl --insecure https://localhost/data` results in `Access Denied.`, indicating proper routing to minio container
2: `curl --insecure https://localhost/dataplusotherstuff` results in `404`, indicating proper routing to web app container
3: `curl --insecure https://localhost/data/plusotherstuff`  results in `Access Denied.`, indicating proper routing to minio container