### PR TITLE
metadata browser: don't display mongo ids or empty fields

### DIFF
--- a/views/partials/draw-metadata-entries-mongo.ejs
+++ b/views/partials/draw-metadata-entries-mongo.ejs
@@ -31,7 +31,7 @@
                 var value = obj[key]
                 if (key === "folderID") {
                   totalhtml += "<strong><u>" + String(key) + "</strong></u>: <a href='https://<%= hostName %>/minio/data/" + String(value) + "/'>" + String(value) + "</a><br>"
-                } else {
+                } else if (key !== "_id" && obj[key]) {
                   totalhtml += "<strong><u>" + String(key) + "</strong></u>: " + String(value) + "<br>"
                 }
                 //username = obj["username"]


### PR DESCRIPTION
### purpose ###
Currently, the metadata browser lists each entry's MongoDB ID. Users don't need to see this, and it may cause confusion. Also currently, the metadata browser draws metadata fields even when their values are empty. Together, these behaviors lead to rows like this one causing unnecessary clutter:

![minimo_issue_19](https://user-images.githubusercontent.com/2954791/101976025-34471780-3bf6-11eb-9a84-fdc0548d18e5.png)

This change fixes these behaviors by not drawing MongoDB IDs or empty metadata rows.

### testing ###
1. Rebuild app with `docker-compose up -d --build --force-recreate`
2. Go to metadata browser at `https://minimo.localhost/browse-datametadata`
3. `ctrl + f` for "_id" (the MongoDB ID key) and verify that it is not present
4. `ctrl + f` for a row which previously contained empty fields and verify that it now does not