### PR TITLE
Issue 8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       HOST_NAME: "${HOST_NAME:-minimo.localhost}"
       MINIO_ACCESS_KEY: "${MINIO_ACCESS_KEY:-minioadmin}"
       MINIO_SECRET_KEY: "${MINIO_SECRET_KEY:-minioadmin}"
+      MINIO_REGION: "${MINIO_REGION:-}"
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.web-app-minimo.rule=Host(`${HOST_NAME:-minimo.localhost}`)"

--- a/server.js
+++ b/server.js
@@ -20,7 +20,7 @@ const minioClient = new Minio.Client({
   useSSL: false,
   accessKey: process.env.MINIO_ACCESS_KEY,
   secretKey: process.env.MINIO_SECRET_KEY,
-  region: ''
+  region: process.env.MINIO_REGION
 });
 
 // for mongodb

--- a/server.js
+++ b/server.js
@@ -20,6 +20,7 @@ const minioClient = new Minio.Client({
   useSSL: false,
   accessKey: process.env.MINIO_ACCESS_KEY,
   secretKey: process.env.MINIO_SECRET_KEY,
+  region: ''
 });
 
 // for mongodb


### PR DESCRIPTION
### purpose ###
Fixes a breaking MinIO issue on AWS hosts detailed in #8. Adds a `region` argument to the MinIO client constructor which defaults to empty string and can be set through the `MINIO_REGION` Docker flag.

### testing ###
Local: verify that default value doesn't break MinIO functionality.
1. Recreate app with `docker-compose up -d --build --force-recreate`
2. Go to `minimo.localhost` and upload new data and metadata
3. Confirm that upload completed successfully and that new data are visible in metadata and data browsers

Cloud:
1. Recreate app with `MINIO_REGION='us-east-1' docker-compose up -d --build --force-recreate`
2. Go to `minimo.localhost` and upload new data and metadata
3. Confirm that upload completed successfully and that new data are visible in metadata and data browsers

Local testing has been completed successfully. Our cloud host is currently being used for iterating on #21, so I'm going to merge this into `master` and then merge it into `issue_21` and verify on the cloud host that it actually fixes the problem. Will comment below with outcome.