### PR TITLE
Issue 25

### DIFF
--- a/server.js
+++ b/server.js
@@ -573,6 +573,9 @@ app.get('/browse-data', checkAuth, (req, res) => {
     res.locals.accessKey = process.env.MINIO_ACCESS_KEY;
     res.locals.secretKey = process.env.MINIO_SECRET_KEY;
 
+    // add prefix from querystring to locals
+    res.locals.prefix = (req.query && req.query.prefix ? req.query.prefix : '');
+
     // render browse data page
     res.render('pages/browse-data');
   } catch (err) {

--- a/views/pages/browse-data.ejs
+++ b/views/pages/browse-data.ejs
@@ -17,7 +17,7 @@
 
             <div id="content">
 
-                <% var minioBrowserUrl = "https://" + hostName + "/minio/data"; %>
+                <% var minioBrowserUrl = "https://" + hostName + "/minio/data" + prefix; %>
                 <iframe id="minio-browser" src=<%= minioBrowserUrl %> onload="checkMinioBrowserLoaded();"></iframe>
 
             </div>>

--- a/views/pages/manage-data.ejs
+++ b/views/pages/manage-data.ejs
@@ -26,7 +26,7 @@
 						Welcome <span class="username"><%= username%></span> to the data management page!
 					</p>
 					<p>
-						First, please select what you want to do.
+						Your data upload was successful! If you would like to perform more data management, please select an action from the options below.
 					</p>
 				</div>
 			</div>

--- a/views/pages/manage-users.ejs
+++ b/views/pages/manage-users.ejs
@@ -40,35 +40,37 @@
 				</div>
 			</div>
 
-			<!-- remove -->
-			<div id="remove" class="box">
-				<div>
+			<% if ( locals.loggedIn ) { %>
+				<!-- remove -->
+				<div id="remove" class="box">
+					<div>
 
-					<p class="form-label">REMOVE a user</p>
+						<p class="form-label">REMOVE a user</p>
 
-					<form action="/remove-user" method="post" id="removeUserForm" class="manage-users-form">
-						<input name="username" id="usernameRemove" type="text", placeholder="username">
-					</form>
-					
-					<!-- Include a submit form field -->
-					<button class="manage-users-button" type="submit" form="removeUserForm">remove user</button>
+						<form action="/remove-user" method="post" id="removeUserForm" class="manage-users-form">
+							<input name="username" id="usernameRemove" type="text", placeholder="username">
+						</form>
+						
+						<!-- Include a submit form field -->
+						<button class="manage-users-button" type="submit" form="removeUserForm">remove user</button>
+					</div>
 				</div>
-			</div>
 
-			<!-- toggle admin -->
-			<div id="admin" class="box">
-				<div>
+				<!-- toggle admin -->
+				<div id="admin" class="box">
+					<div>
 
-					<p class="form-label">toggle user ADMIN status</p>
+						<p class="form-label">toggle user ADMIN status</p>
 
-					<form action="/toggle-admin" method="post" id="toggleAdminForm" class="manage-users-form">
-						<input name="username" id="usernameToggleAdmin" type="text", placeholder="username">
-					</form>
-					
-					<!-- Include a submit form field -->
-					<button class="manage-users-button" type="submit" form="toggleAdminForm">toggle admin</button>
+						<form action="/toggle-admin" method="post" id="toggleAdminForm" class="manage-users-form">
+							<input name="username" id="usernameToggleAdmin" type="text", placeholder="username">
+						</form>
+						
+						<!-- Include a submit form field -->
+						<button class="manage-users-button" type="submit" form="toggleAdminForm">toggle admin</button>
+					</div>
 				</div>
-			</div>
+			<% } %>
 
 			<div id="userTable" class="box"></div>
 		</div>

--- a/views/partials/draw-metadata-entries-mongo.ejs
+++ b/views/partials/draw-metadata-entries-mongo.ejs
@@ -20,7 +20,7 @@
 
                 var value = obj[key]
                 if (key === "folderID") {
-                  totalhtml += "<strong>" + String(key) + "</strong>: <a href='https://<%= hostName %>/minio/data/" + String(value) + "/' class='metadata-link'>" + String(value) + "</a><br>"
+                  totalhtml += "<strong>" + String(key) + "</strong>: <a href='https://<%= hostName %>/browse-data?prefix=/" + String(value) + "/' class='metadata-link'>" + String(value) + "</a><br>"
                 } else if (key !== "_id" && obj[key]) {
                   totalhtml += "<strong>" + String(key) + "</strong>: " + String(value) + "<br>"
                 }


### PR DESCRIPTION
### Purpose ###
Closes #25.

### Testing ###
1: Build changes with `docker-compose up -d --build --force-recreate`.
2: Check functionality on all affected pages:

`browse-data`: `https://minimo.localhost/browse-data` loads successfully, and folder navigation works properly once loaded. clicking on `folderID` hyperlink at `browse-datametadata` loads `browse-data` with embedded MinIO browser at correct folder.

`manage-users`: When `https://minimo.localhost/manage-users` is loaded with no users added, only `add user` form is visible. After adding user and logging in, all forms are visible. After adding additional user and toggling that user to admin, first user only sees `update password` form. After logging in with admin user, all forms are visible again. All forms remain visible after toggling admin on second user to set total number of admins to zero. Removing all users results in only `add user` being visible again.

`manage-data`: Upload data and metadata. Confirm that new copy shows on `manage-data` after upload redirect.