### PR TITLE
set overflow for bucket and folder selectors to scroll

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -288,7 +288,8 @@ button.myform {
 	left: 30px;
 	margin: 0 auto;
 	background-color: #fff;
-	border: 1px solid #777
+	border: 1px solid #777;
+	overflow: scroll;
 }
 
 #folder-selector-container {
@@ -299,7 +300,8 @@ button.myform {
 	margin: 0 auto;
 	text-align: center;
 	background-color: #fff;
-	border: 1px solid #777
+	border: 1px solid #777;
+	overflow: scroll;
 }
 
 #selector {


### PR DESCRIPTION
### Purpose ###
Fixes #28.

### Testing ###
1. Build changes locally with `docker-compose up -d --build --force-recreate`
2. Go to `https://minimo.localhost/submit-data-boxuploader` and select a folder with enough entries to overflow selection box vertical space (62 files in test folder I used)
3. Verify that scroll bars are created for selector entries (instead of entries overflowing past container)
4. Go to `https://minimo.localhost/link-metadata-to-data`
5. Open debugging tools and reduce height of `#bucket-selector-container` to a height too small to accommodate existing selector entries (I used 60px)
6. Verify that scroll bars are created for selector entries (instead of entries overflowing past container)