### PR TITLE
Smoke test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,5 +10,7 @@ jobs:
         run: HOST_NAME=localhost docker-compose up -d --build --force-recreate
       - name: Get landing page content
         id: curl-landing-page
-        run: echo '::set-output name=landing-page-content::$(docker run --network container:minimo_reverse-proxy_1 appropriate/curl -s --retry 10 --retry-connrefused --insecure https://localhost)'
-        
+        # multiline strings require special handling in actions. see https://trstringer.com/github-actions-multiline-strings/ and https://github.com/actions/toolkit/blob/main/docs/commands.md#set-an-environment-variable
+        run: echo 'LANDING_PAGE_HTML<<EOF' >> $GITHUB_ENV && curl -s --retry 10 --retry-connrefused --insecure https://localhost >> $GITHUB_ENV && echo 'EOF' >> $GITHUB_ENV
+      - name: Print html
+        run: echo "HTML is: ${{ env.LANDING_PAGE_HTML }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
           docker run --network container:minimo_reverse-proxy_1 appropriate/curl -s --retry 10 --retry-connrefused --insecure https://localhost >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
       - name: Validate landing page
-        if: "!contains($LANDING_PAGE_HTML, 'Welcome to the minimo FAQ!')"
+        if: "!contains(env.LANDING_PAGE_HTML, 'Welcome to the minimo FAQ!')"
         run: |
           echo -e "\nExpected landing page content not found. Actual content was:\n\n$LANDING_PAGE_HTML"
           exit 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
           docker run --network container:minimo_reverse-proxy_1 appropriate/curl -s --retry 10 --retry-connrefused --insecure https://localhost >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
       - name: Validate landing page
-        if: "!contains(env.LANDING_PAGE_HTML, 'Welcome to the minimo FAQ!')"
+        if: "!contains(env.LANDING_PAGE_HTML, 'NOT Welcome to the minimo FAQ!!!')"
         run: |
           echo -e "\nExpected landing page content not found. Actual content was:\n\n$LANDING_PAGE_HTML"
           exit 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,10 @@ jobs:
       - name: Get landing page content
         id: curl-landing-page
         # multiline strings require special handling in actions. see https://trstringer.com/github-actions-multiline-strings/ and https://github.com/actions/toolkit/blob/main/docs/commands.md#set-an-environment-variable
-        run: echo 'LANDING_PAGE_HTML<<EOF' >> $GITHUB_ENV && curl -s --retry 10 --retry-connrefused --insecure https://localhost >> $GITHUB_ENV && echo 'EOF' >> $GITHUB_ENV
+        run: |
+          echo 'LANDING_PAGE_HTML<<EOF' >> $GITHUB_ENV
+          curl -s --retry 10 --retry-connrefused --insecure https://localhost >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
       - name: Print html
-        run: echo "HTML is: ${{ env.LANDING_PAGE_HTML }}"
+        run: |
+          echo "The string is: ${{ env.LANDING_PAGE_HTML }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
         # multiline strings require special handling in actions. see https://trstringer.com/github-actions-multiline-strings/ and https://github.com/actions/toolkit/blob/main/docs/commands.md#set-an-environment-variable
         run: |
           echo 'LANDING_PAGE_HTML<<EOF' >> $GITHUB_ENV
-          curl -s --retry 10 --retry-connrefused --insecure https://localhost >> $GITHUB_ENV
+          docker run --network container:minimo_reverse-proxy_1 appropriate/curl -s --retry 10 --retry-connrefused --insecure https://localhost >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
       - name: Print html
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,14 @@
+# from https://github.com/peter-evans/docker-compose-actions-workflow
+name: Docker Compose Actions Workflow
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build the app
+        run: HOST_NAME=localhost docker-compose up -d --build --force-recreate
+      - name: Get landing page content
+        id: curl-landing-page
+        run: echo '::set-output name=landing-page-content::$(docker run --network container:minimo_reverse-proxy_1 appropriate/curl -s --retry 10 --retry-connrefused --insecure https://localhost)'
+        

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,8 @@ jobs:
           echo 'LANDING_PAGE_HTML<<EOF' >> $GITHUB_ENV
           docker run --network container:minimo_reverse-proxy_1 appropriate/curl -s --retry 10 --retry-connrefused --insecure https://localhost >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
-      - name: Print html
+      - name: Validate landing page
+        if: "!contains($LANDING_PAGE_HTML, 'Welcome to the minimo FAQ!')"
         run: |
-          echo -e "The string is: $LANDING_PAGE_HTML"
+          echo -e "\nExpected landing page content not found. Actual content was:\n\n$LANDING_PAGE_HTML"
+          exit 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,4 +17,4 @@ jobs:
           echo 'EOF' >> $GITHUB_ENV
       - name: Print html
         run: |
-          echo -e "The string is: ${{ env.LANDING_PAGE_HTML }}"
+          echo -e "The string is: $LANDING_PAGE_HTML"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
           docker run --network container:minimo_reverse-proxy_1 appropriate/curl -s --retry 10 --retry-connrefused --insecure https://localhost >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
       - name: Validate landing page
-        if: "!contains(env.LANDING_PAGE_HTML, 'NOT Welcome to the minimo FAQ!!!')"
+        if: "!contains(env.LANDING_PAGE_HTML, 'Welcome to the minimo FAQ!')"
         run: |
           echo -e "\nExpected landing page content not found. Actual content was:\n\n$LANDING_PAGE_HTML"
           exit 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,4 +17,4 @@ jobs:
           echo 'EOF' >> $GITHUB_ENV
       - name: Print html
         run: |
-          echo "The string is: ${{ env.LANDING_PAGE_HTML }}"
+          echo -e "The string is: ${{ env.LANDING_PAGE_HTML }}"


### PR DESCRIPTION
### Purpose ###
Add a simple smoke test action. This action builds the app, connects to it via the reverse proxy, and verifies that the landing page header is present in the response. It is triggered by code push.

### Testing ###
Automated smoke test passes :)

I've also verified that it *doesn't* pass when the expected welcome header string is changed to one that isn't present.