### PR TITLE
front end and back end blocking of illegal object names

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -270,6 +270,13 @@ button.myform {
 	display: inline-block;
 }
 
+#invalid-object-name-error-message {
+	position: relative;
+	left: 30px;
+	margin: 0 auto;
+	width: 500px;
+}
+
 #metadata_form_label {
 	position: relative;
 	left: 30px;
@@ -345,4 +352,12 @@ button.myform {
 
 #userTable > table > tbody > tr > th {
 	padding-right: 7.5em;
+}
+
+.illegal-object-name {
+	color: #f00;
+}
+
+.error-text {
+	color: #f00;
 }

--- a/views/pages/submit-data-boxuploader.ejs
+++ b/views/pages/submit-data-boxuploader.ejs
@@ -34,17 +34,26 @@
                 <ul id="selected_files">Select a data folder for upload.</ul>
 
                 <script type="text/javascript">
+                    const valid_object_name = <%- valid_object_name %>;
                     // display selected filenames when selection is made (from https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/webkitdirectory)
                     document.getElementById("selector").addEventListener("change", function(event) {
+                        document.getElementById("invalid-object-name-error-message").classList.add("hidden");
                         let selection_list = document.getElementById("selected_files");
                         selection_list.innerHTML = "";
                         let selected_files = event.target.files;
-
+                        let all_object_names_valid = true;
                         for (let i=0; i < selected_files.length; i++) {
                             let item = document.createElement("li");
-                            item.innerHTML = selected_files[i].webkitRelativePath;
+                            let relativePath = selected_files[i].webkitRelativePath;
+                            item.innerHTML = relativePath;
+                            if (! valid_object_name.test(relativePath)) {
+                                all_object_names_valid = false;
+                                item.classList.add("illegal-object-name");
+                                document.getElementById("invalid-object-name-error-message").classList.remove("hidden");
+                            }
                             selection_list.appendChild(item);
                         };
+                        document.getElementById("submit-data-submit-button").disabled = ! all_object_names_valid;
                     }, false);
 
                     // first iterate through all selected files and invoke a helper function called `retrieveNewURL` to upload them to MinIO
@@ -68,6 +77,8 @@
                         }
                         Promise.all(promises).then(() => {
                             submitMetadataForm();
+                        }).catch(error => {
+                            console.error(error.message);
                         })
                     }
 
@@ -76,12 +87,14 @@
                     function retrieveNewURL(file, cb) {
                         return new Promise((resolve) => {
                             fetch(`/presigned-url?name=${file.webkitRelativePath}`).then((response) => {
-                                response.text().then((url) => {
-                                    cb(file, url.replace("http:", "https:"), resolve);
-                                });
-                        })
-                        }).catch((e) => {
-                            console.error(e);
+                                if (response.ok) {
+                                    response.text().then((url) => {
+                                        cb(file, url.replace("http:", "https:"), resolve);
+                                    });
+                                } else {
+                                    throw new Error("Error while putting file " + file.webkitRelativePath);
+                                }
+                            })
                         });
                     }
 
@@ -156,7 +169,10 @@
                     }
 
                 </script>
-            </div> 
+            </div>
+            <div id="invalid-object-name-error-message" class="hidden">
+                <p class="error-text"> One of more the objects that you have selected for upload has an invalid filename. Files selected for upload must have names which comprise only alphanumeric characters (a-z, A-Z, and 0-9) and the special characters /!-_.*'(). Additionally, names of files for upload must have lengths of at least 1 character and no more than 1024 characters.</p>
+            </div>
 
             <br><br>
 
@@ -177,7 +193,7 @@
 
             <% include ../partials/metadata-form-mongo %>
 
-            <button class="myform" onclick="upload()">submit</button>
+            <button id="submit-data-submit-button" class="myform" onclick="upload()">submit</button>
         </div>
     </div>
 


### PR DESCRIPTION
### Purpose ###
It looks like illegally named objects may be complicating our attempts create data backups through MinIO. This change is intended to enforce the object naming rules specified at https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html. Rules are validated both on the front end (during the upload flow) and on the back end (in the fetch pre-signed URL route).

### Testing ###
1. Build changes with `docker-compose up -d --build --force-recreate`
2. Go to `https://minimo.localhost/submit-data-boxuploader` and select a folder for upload which contains both a legally named file `legal_name.jpg` and an illegally named file `illegal name.jpg`
3. Verify that error text appears below folder selector, that illegal file name is highlighted with red text, and that legal file name is not highlighted
4. Verify that submit button on page is disabled
5. Open browser console and re-enable submit button with `document.getElementById("submit-data-submit-button").disabled = false;`
6. Enter text in comments field which can be used later to identify upload in metadata browser
7. Click upload
8. Verify in console that error occurred while fetching pre-signed URL for illegally named file
9. Verify that post-upload redirect does not occur
10. Go to metadata browser and search for the text entered in step 6 to verify that metadata was not uploaded to MongoDB
11. Delete illegally named file locally
12. Return to `https://minimo.localhost/submit-data-boxuploader,` complete upload flow again with same folder, and verify that upload was successful this time