### PR TITLE
add etcd container and connect to minio

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,8 @@ services:
 
   minio:
     image: minio/minio
+    depends_on:
+      - etcd
     expose:
       - "80"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
     environment:
       MINIO_ACCESS_KEY: "${MINIO_ACCESS_KEY:-minioadmin}"
       MINIO_SECRET_KEY: "${MINIO_SECRET_KEY:-minioadmin}"
+      MINIO_ETCD_ENDPOINTS: "http://etcd:2379"
     entrypoint: sh
     command: -c 'mkdir -p /data/data && /usr/bin/minio ${MINIO_COMMAND:-server} --address :80 /data'
     volumes:
@@ -59,6 +60,17 @@ services:
       - "traefik.http.routers.minio-minimo.tls=true"
       - "traefik.frontend.passHostHeader=true"
     # docker run -p 9000:9000 --name minimo-minio -d minio/minio server /data
+
+  etcd:
+    image: 'bitnami/etcd:latest'
+    environment:
+      - ALLOW_NONE_AUTHENTICATION=yes
+      - ETCD_ADVERTISE_CLIENT_URLS=http://etcd:2379
+    expose:
+      - "2379"
+      - "2380"
+    networks:
+      net:
 
   mc:
     image: minio/mc

--- a/server.js
+++ b/server.js
@@ -293,10 +293,8 @@ app.get('/submit-data-boxuploader', checkAuth, (req, res) => {
 
         // grab returned docs
         docs = resolve;
-        // console.log('docs0: ' + JSON.stringify(docs[0]))
 
         // add docs to locals
-        console.log(JSON.stringify(docs));
         res.locals.docs = JSON.stringify(docs);
         res.locals.username = getUsername(req);
         res.locals.valid_object_name = valid_object_name;
@@ -378,7 +376,6 @@ app.get('/manage-forms', checkAuth, (req, res) => {
 
         // grab returned docs
         docs = resolve;
-        // console.log('docs0: ' + JSON.stringify(docs[0]))
 
         // add docs to locals
         res.locals.docs = JSON.stringify(docs);
@@ -528,10 +525,8 @@ app.get('/link-metadata-to-data', checkAuth, (req, res) => {
 
         // grab returned docs
         docs = resolve;
-        // console.log('docs0: ' + JSON.stringify(docs[0]))
 
         // add docs to locals
-        console.log(JSON.stringify(docs));
         res.locals.docs = JSON.stringify(docs);
         res.locals.username = getUsername(req);
 
@@ -571,7 +566,6 @@ app.get('/browse-datametadata', checkAuth, (req, res) => {
 
             // grab returned docs
             docs = resolve;
-            console.log(`docs0: ${JSON.stringify(docs[0])}`);
 
             // get formatted docs
             formattedDocs = formatMetadataEntriesForDisplay(docs, metadata_fields);


### PR DESCRIPTION
### Purpose ###
The `mc` container added in #46 breaks when minimo is deployed with MinIO in `gateway` mode, because the `admin` API is not supported in `gateway` mode. This change enables use of the `admin` API in `gateway` mode by adding an `etcd` container and relevant configuration.

Additionally, this change fixes a race condition which was introduced in #46 (and believed to have been fixed before that change was merged). The root cause for this race is that the presigned-urls endpoint did not wait for all of its async calls to MinIO to complete before returning a response, which could result in an empty `urls` list in the response. If the submit data page returned such a response, it would believe that it had no PUTs to perform, and it would consequently upload metadata without uploading the associated data.

### Testing ###
etcd:
1. Deploy without `gateway` mode with `docker-compose up -d --build --force-recreate`
2. Verify that you can still upload a file through the submit page and find your upload in the metadata browser
3. Verify that readlist permissions still work by confirming that you are unable to delete files through the data browser
4. Deploy with `gateway` mode with `MINIO_COMMAND=gateway\ nas docker-compose up -d --build --force-recreate`
5. Verify that you can still upload a file through the submit page and find your upload in the metadata browser
6. Verify that readlist permissions still work by confirming that you are unable to delete files through the data browser

race:
1. Upload the same folder a few times without refreshing or hard refreshing in between
2. Verify that all data files were uploaded each time