### PR TITLE
Issue 36

### DIFF
--- a/javascripts/form-element-strings.js
+++ b/javascripts/form-element-strings.js
@@ -69,7 +69,7 @@ function formElementStringToObj(formJSONString) {
 
     if ('dropdown' === element_type) {
       let options = [];
-      for (j = 2; j < lines.length; j++) {
+      for (j = 3; j < lines.length; j++) {
         // remove leading/trailing whitespace
         trimmed = lines[j].trim();
         if (trimmed.length > 0) {

--- a/javascripts/mongo-db.js
+++ b/javascripts/mongo-db.js
@@ -61,6 +61,28 @@ DB.prototype.uploadDocument = function (documentToUpload, myCollection, isUpdate
   }));
 };
 
+DB.prototype.incrementField = function (query, myCollection, fieldToIncrement, amountToIncrement) {
+  // scoping
+  _this = this;
+
+  return new Promise(((resolve, reject) => {
+    // more scoping
+    __this = _this;
+
+    // connect (if not already)
+    __this.connect(mongoConfig.MONGODB_URI)
+    .then( () => {
+      __this.db.collection(myCollection).update(
+        query,
+        { $inc: { [fieldToIncrement]: amountToIncrement } }
+      ).then( () => {
+        console.log('Successful field incrementation!');
+        resolve();
+      });
+    });
+  }));
+};
+
 DB.prototype.deleteDocument = function (documentToDelete, myCollection) {
   // scoping
   _this = this;

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -449,3 +449,16 @@ label.metadata-field-label {
 	color: #f00;
 	margin-bottom: 0;
 }
+
+#confirmDelete {
+	padding-top: 1em;
+}
+
+#confirmDelete > p {
+	display: inline-block;
+}
+
+#confirmButton {
+	display: block;
+	margin: auto;
+}

--- a/views/pages/link-metadata-to-data.ejs
+++ b/views/pages/link-metadata-to-data.ejs
@@ -35,7 +35,6 @@
                 function retrieveDataObjects(prefix)  {
                     fetch(`/list-data-objects?prefix=${prefix}`).then((response) => {
                         response.json().then((data) => {
-                            console.log(data);
 
                             var parent_list = document.getElementById(prefix === "" ? "bucket_browser" : prefix + "_folder");
                             for (var i = 0; i < data.length; i++) {
@@ -110,7 +109,10 @@
                         var fl = '{ "fl" : ["linked"], "folderID":"' + folderID + '"}'
 
                         // take the filelist (data from event) and append to form
-                        document.getElementById('metadata_form').filelist.value = fl
+                        document.getElementById('metadata_form').filelist.value = fl;
+
+                        // add list of forms used in submission
+                        document.getElementById('metadata_form')['submitted form counts'].value = JSON.stringify(countFormUses());
 
                         // submit the form
                         document.getElementById('metadata_form').submit()
@@ -145,6 +147,8 @@
             <br><br>
 
             <% include ../partials/metadata-form-mongo %>
+
+            <% include ../partials/count-form-uses %>
 
             <button class="myform" onclick="submitForm()">submit</button>
 

--- a/views/pages/manage-forms.ejs
+++ b/views/pages/manage-forms.ejs
@@ -99,6 +99,8 @@
 			option2.setAttribute("disabled", true)
 			option.setAttribute("selected", true)
 			option2.setAttribute("selected", true)
+			option.setAttribute("hidden", true)
+			option2.setAttribute("hidden", true)
 			editSelect.add(option)
 			deleteSelect.add(option2)
 

--- a/views/pages/manage-forms.ejs
+++ b/views/pages/manage-forms.ejs
@@ -67,7 +67,7 @@
 					</form>
 					
 					<div class="hidden" id="confirmDelete">
-						<p>Clicking "delete" will delete the form "</p><p id="confirmFormName"></p><p>." This form has been used to submit metadata </p><p id="confirmFormUses"></p><p> times. Please confirm that this is what you wish to do.</p>
+						<p>Clicking "delete" will delete the form "</p><p id="confirmFormName"></p><p>." This form has been used for&nbsp;</p><p id="confirmFormUses"></p><p>&nbsp;metadata submissions. Please confirm that this is what you wish to do.</p>
 						<button id="confirmButton" onclick="enableDelete()">Confirm</button>
 					</div>
 

--- a/views/pages/manage-forms.ejs
+++ b/views/pages/manage-forms.ejs
@@ -68,7 +68,7 @@
 					
 					<div class="hidden" id="confirmDelete">
 						<p>Clicking "delete" will delete the form "</p><p id="confirmFormName"></p><p>." This form has been used for&nbsp;</p><p id="confirmFormUses"></p><p>&nbsp;metadata submissions. Please confirm that this is what you wish to do.</p>
-						<button id="confirmButton" onclick="enableDelete()">Confirm</button>
+						<button id="confirmButton" onclick="enableDelete()">confirm</button>
 					</div>
 
 					<!-- Include a submit form field -->

--- a/views/pages/manage-forms.ejs
+++ b/views/pages/manage-forms.ejs
@@ -56,7 +56,7 @@
 					<p class="form-label">DELETE a metadata form entry.</p>
 
 					<form action="/delete-form-entry" method="post" id="deleteForm">
-						<select class="myform" id="deleteSelect" name="deleteSelect">
+						<select class="myform" id="deleteSelect" name="deleteSelect" onchange="confirmDelete()">
 						</select>
 
 						<!-- Hidden text form for uid -->
@@ -66,8 +66,13 @@
 
 					</form>
 					
+					<div class="hidden" id="confirmDelete">
+						<p>Clicking "delete" will delete the form "</p><p id="confirmFormName"></p><p>." This form has been used to submit metadata </p><p id="confirmFormUses"></p><p> times. Please confirm that this is what you wish to do.</p>
+						<button id="confirmButton" onclick="enableDelete()">Confirm</button>
+					</div>
+
 					<!-- Include a submit form field -->
-					<button class="myform myform-red" onclick="submitForm('deleteForm')">delete</button>
+					<button class="myform myform-red" id="deleteButton" onclick="submitForm('deleteForm')">delete</button>
 				</div>
 			</div>
 		</div>
@@ -84,6 +89,18 @@
 			// get form information
 			var docsObject = <%- docs %>;
 			var fieldToGrab = "form name"
+
+			// create default blank options
+			var option = document.createElement("option")
+			var option2 = document.createElement("option")
+			option.text = 'select form'
+			option2.text = 'select form'
+			option.setAttribute("disabled", true)
+			option2.setAttribute("disabled", true)
+			option.setAttribute("selected", true)
+			option2.setAttribute("selected", true)
+			editSelect.add(option)
+			deleteSelect.add(option2)
 
 			i = 0
 			while (i < docsObject.length){
@@ -110,6 +127,27 @@
 				i = i + 1
 
 			}
+		}
+
+		function confirmDelete() {
+			let docsObject = <%- docs %>;
+			let selectedFormName = document.getElementById('deleteSelect').value;
+			for (i = 0; i < docsObject.length; i++) {
+				if (docsObject[i]['form name'] === selectedFormName) {
+					if (docsObject[i]['uses']) {
+						let uses = docsObject[i]['uses'];
+						document.getElementById('deleteButton').disabled = true;
+						document.getElementById('confirmDelete').classList.remove('hidden');
+						document.getElementById('confirmFormName').innerHTML = selectedFormName;
+						document.getElementById('confirmFormUses').innerHTML = uses;
+					}
+					break;
+				}
+			}
+		}
+
+		function enableDelete() {
+			document.getElementById('deleteButton').disabled = false;
 		}
 
 		// helper function to submit form

--- a/views/pages/submit-data-boxuploader.ejs
+++ b/views/pages/submit-data-boxuploader.ejs
@@ -130,6 +130,9 @@
                         document.getElementById('metadata_form').filelist.value = fl
                         var mdf = document.getElementById('metadata_form');
 
+                        // add counts of forms used in submission
+                        document.getElementById('metadata_form')['submitted form counts'].value = countFormUses();
+
                         // submit the form
                         document.getElementById('metadata_form').submit()
 
@@ -166,6 +169,8 @@
             <br><br>
 
             <% include ../partials/metadata-form-mongo %>
+
+            <% include ../partials/count-form-uses %>
 
             <button id="submit-data-submit-button" class="myform" onclick="upload()">submit</button>
         </div>

--- a/views/pages/submit-data-boxuploader.ejs
+++ b/views/pages/submit-data-boxuploader.ejs
@@ -131,7 +131,7 @@
                         var mdf = document.getElementById('metadata_form');
 
                         // add counts of forms used in submission
-                        document.getElementById('metadata_form')['submitted form counts'].value = countFormUses();
+                        document.getElementById('metadata_form')['submitted form counts'].value = JSON.stringify(countFormUses());
 
                         // submit the form
                         document.getElementById('metadata_form').submit()

--- a/views/partials/count-form-uses.ejs
+++ b/views/partials/count-form-uses.ejs
@@ -1,0 +1,29 @@
+<script>
+    function countFormUses() {
+        let forms_used = {};
+        let form_details = document.getElementsByClassName('metadata-form-collapsible');
+        for (i = 0; i < form_details.length; i++) {
+            let form_elements = form_details[i].children;
+            let form_name;
+            let form_used = false;
+            for (j = 0; j < form_elements.length; j++) {
+                let element = form_elements[j];
+                if (element.tagName === 'SUMMARY') {
+                    form_name = element.getAttribute('data-text');
+                } else if (element.tagName === 'INPUT' || element.tagName === 'TEXTAREA' || element.tagName === 'SELECT') {
+                    if (element.value) {
+                        form_used = true;
+                    }
+                }
+                if (form_used && form_name) {
+                    if (! (form_name in forms_used) ) {
+                        forms_used[form_name] = 0;
+                    }
+                    forms_used[form_name] += 1;
+                    break;
+                }
+            }
+        }
+        return forms_used;
+    }
+</script>

--- a/views/partials/draw-experiment-forms-mongo.ejs
+++ b/views/partials/draw-experiment-forms-mongo.ejs
@@ -118,6 +118,8 @@
 
 		totalhtml += "<div class=\"hidden\"><input name=\"date uploaded\" type=\"text\" value=\"" + String(yyyy + mm + dd) + "\"></div>"
 
+		totalhtml += "<div class=\"hidden\"><input name=\"submitted form counts\" type=\"text\"></div>"
+
 
 		// add all that html in...
 		document.getElementById('metadata_form').innerHTML = totalhtml


### PR DESCRIPTION
### Purpose ###
Track form submission counts, and display confirmation prompt showing number of form uses before allowing form deletion. Closes #36. Considered a high priority item for https://github.com/openjournals/joss-reviews/issues/2979.

### Testing ###
1. Deploy locally with `docker-compose up -d --build --force-recreate`
2. Create a new metadata form that you can delete during testing
3. Upload data and include an entry for your new metadata field
4. Confirm that you can see your uploaded data in the data browser and your uploaded metadata in the metadata browser
5. Go to manage forms and select the form you used for deletion
6. Verify that you get a confirmation prompt saying that the form has been used for one submission and that `delete` button is disabled
7. Click `confirm`
8. Verify that `delete` button is enabled
9. Click `delete`
10. Go to manage forms again and confirm that your form has been deleted
11. Go to link new metadata to existing data page
12. Select a data folder, set number of experiments to two, and add an entry for the same metadata form for both experiments, and click `submit`
13. Go to manage forms, select the form you used for deletion, and verify that the confirmation prompt specifies that the form has been used twice
14. Go to manage forms, click `edit` button without making a selection, and confirm that you are brought to create new form page
15. Go to manage forms, click `delete` button without making a selection, and confirm that no forms were deleted